### PR TITLE
Add root redirect page for dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="refresh" content="0; url=analysis/index.html" />
+  <title>Redirecting…</title>
+  <link rel="canonical" href="analysis/index.html" />
+  <style>
+    body {
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #f4f6fb;
+      color: #1b1e28;
+    }
+    main {
+      text-align: center;
+      max-width: 32rem;
+      padding: 2rem;
+      background: white;
+      border-radius: 1rem;
+      box-shadow: 0 16px 40px rgba(27, 30, 40, 0.12);
+    }
+    a {
+      color: #145afc;
+      font-weight: 600;
+      text-decoration: none;
+    }
+    p {
+      margin: 0.75rem 0 0;
+      color: #5f677b;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Redirecting to the dashboard…</h1>
+    <p>If you are not redirected automatically, <a href="analysis/index.html">click here to open the Gross Proceed dashboard</a>.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a root-level index.html that redirects visitors to the dashboard in the analysis folder
- provide a styled fallback message with a manual link for environments that block automatic redirects

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d61a5a8fa083298059c9142ce1d30a