### PR TITLE
Make regular table headers sticky and adjust layout

### DIFF
--- a/analysis/index.html
+++ b/analysis/index.html
@@ -108,6 +108,15 @@
     th, td {
       text-align: left;
       padding: 0.5rem 0.75rem;
+      border-right: 1px solid rgba(27, 30, 40, 0.12);
+    }
+    th:first-child,
+    td:first-child {
+      border-left: 1px solid rgba(27, 30, 40, 0.12);
+    }
+    th:last-child,
+    td:last-child {
+      border-right: 1px solid rgba(27, 30, 40, 0.12);
     }
     th {
       color: var(--muted);
@@ -120,7 +129,7 @@
     }
     .table-container {
       position: relative;
-      overflow: hidden;
+      overflow: visible;
       padding-right: 1.5rem;
       padding-bottom: 1.5rem;
     }
@@ -133,6 +142,11 @@
       letter-spacing: 0.04em;
       text-transform: uppercase;
       color: var(--muted);
+      position: sticky;
+      top: var(--sticky-header-offset);
+      background: var(--card-bg);
+      z-index: 6;
+      border-bottom: 1px solid rgba(27, 30, 40, 0.12);
     }
     #regular-table thead th.is-filterable {
       cursor: pointer;
@@ -155,7 +169,9 @@
     }
     #regular-table th.cell-product,
     #regular-table td.cell-product {
-      white-space: nowrap;
+      width: 16ch;
+      white-space: normal;
+      word-break: break-word;
     }
     #regular-table_wrapper {
       padding-right: 0.5rem;


### PR DESCRIPTION
## Summary
- keep the Regular dataset table headers visible during vertical scrolling with sticky positioning
- constrain the Product column to a compact width so product names wrap within 2–3 words
- add subtle vertical dividers between table columns for better readability

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6475fd58c8329ba574960ccc05c11