### PR TITLE
Add listing owner sales and spend dashboard

### DIFF
--- a/analysis/index.html
+++ b/analysis/index.html
@@ -9,7 +9,6 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" />
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <style>
     :root {
@@ -68,101 +67,101 @@
     .grid > * {
       min-width: 0;
     }
-    .kpi-grid {
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    .lo-grid {
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     }
-    #tab-analysis {
+    .lo-card {
       display: flex;
       flex-direction: column;
-      gap: 1.5rem;
+      gap: 1rem;
     }
-    #tab-analysis .analysis-grid {
-      grid-template-columns: repeat(12, minmax(0, 1fr));
-      grid-auto-flow: dense;
-      align-items: stretch;
-      gap: 1.25rem;
-      padding-bottom: 2rem;
-    }
-    .analysis-card {
+    .lo-card__header {
       display: flex;
       flex-direction: column;
-      gap: 0.75rem;
+      gap: 0.25rem;
     }
-    .analysis-card .card-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 0.75rem;
-    }
-    .analysis-card .card-title {
-      font-size: 1.05rem;
-      font-weight: 600;
+    .lo-card__title {
       margin: 0;
+      font-size: 1.3rem;
+      font-weight: 600;
       color: var(--text);
     }
-    .analysis-card .card-body {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
+    .lo-card__subtitle {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.95rem;
     }
-    .analysis-card--wide {
-      grid-column: span 7;
-      min-height: 380px;
+    .sub-tab-nav {
+      display: inline-flex;
+      gap: 0.75rem;
+      background: rgba(20, 90, 252, 0.08);
+      padding: 0.4rem;
+      border-radius: 999px;
+      width: fit-content;
     }
-    .analysis-card--narrow {
-      grid-column: span 5;
-      min-height: 380px;
+    .sub-tab-button {
+      border: none;
+      background: transparent;
+      font: inherit;
+      font-weight: 600;
+      color: var(--muted);
+      padding: 0.45rem 1.25rem;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease;
     }
-    .analysis-card--half {
-      grid-column: span 6;
-      min-height: 360px;
+    .sub-tab-button:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
     }
-    .analysis-chart {
-      width: 100% !important;
-      height: 320px !important;
+    .sub-tab-button.active {
+      background: var(--card-bg);
+      color: var(--text);
+      box-shadow: 0 6px 16px rgba(20, 90, 252, 0.15);
     }
-    .analysis-table {
+    .sub-tab-panel {
+      display: none;
+    }
+    .sub-tab-panel.active {
+      display: block;
+    }
+    .lo-table-container {
+      border-radius: 0.75rem;
+      overflow: hidden;
+      border: 1px solid rgba(27, 30, 40, 0.08);
+      box-shadow: inset 0 0 0 1px rgba(27, 30, 40, 0.03), 0 12px 30px rgba(15, 23, 42, 0.08);
+      background: #fff;
+    }
+    .lo-table {
       width: 100%;
       border-collapse: collapse;
-      border-radius: 0.5rem;
-      overflow: hidden;
-      box-shadow: inset 0 0 0 1px rgba(27, 30, 40, 0.08);
-    }
-    .analysis-table thead {
-      background: linear-gradient(180deg, #f7f9ff 0%, #eef1fb 100%);
-    }
-    .analysis-table th,
-    .analysis-table td {
-      padding: 0.65rem 0.75rem;
       font-size: 0.9rem;
-      border-bottom: 1px solid rgba(27, 30, 40, 0.08);
     }
-    .analysis-table th {
+    .lo-table thead th {
       text-transform: uppercase;
-      font-size: 0.75rem;
       letter-spacing: 0.08em;
+      background: linear-gradient(180deg, #f6f8ff 0%, #e3e8f7 100%);
       color: var(--muted);
       font-weight: 600;
+      padding: 0.65rem 0.75rem;
+      text-align: right;
     }
-    .analysis-table tbody tr:last-child td {
-      border-bottom: none;
+    .lo-table thead th:first-child {
+      text-align: left;
     }
-    .analysis-table tbody tr:nth-child(odd) td {
-      background: rgba(226, 231, 244, 0.25);
-    }
-    .analysis-table td.cell-numeric {
+    .lo-table tbody td {
+      padding: 0.55rem 0.75rem;
+      border-top: 1px solid rgba(27, 30, 40, 0.08);
       text-align: right;
       font-variant-numeric: tabular-nums;
     }
-    .analysis-table caption {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      border: 0;
+    .lo-table tbody td.cell-date {
+      text-align: left;
+      font-weight: 600;
+      color: var(--text);
+    }
+    .lo-table tbody tr:nth-child(odd) td {
+      background: rgba(226, 231, 244, 0.25);
     }
     .card {
       background: var(--card-bg);
@@ -525,13 +524,8 @@
       border: 0;
     }
     @media (max-width: 1280px) {
-      #tab-analysis .analysis-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-      .analysis-card--wide,
-      .analysis-card--narrow,
-      .analysis-card--half {
-        grid-column: span 1;
+      .lo-grid {
+        grid-template-columns: 1fr;
       }
     }
     @media (max-width: 900px) {
@@ -549,102 +543,31 @@
 </head>
 <body>
   <nav class="tab-nav" aria-label="Dashboard views">
-    <button class="tab-button active" id="tab-analysis-button" type="button" data-tab="analysis" aria-controls="tab-analysis" aria-selected="true">Analysis</button>
+    <button class="tab-button active" id="tab-lo-button" type="button" data-tab="lo" aria-controls="tab-lo" aria-selected="true">LO - Sales &amp; Spend</button>
     <button class="tab-button" id="tab-regular-button" type="button" data-tab="regular" aria-controls="tab-regular" aria-selected="false">Regular</button>
   </nav>
-  <div class="tab-panel active" id="tab-analysis" data-tab="analysis" role="tabpanel" aria-labelledby="tab-analysis-button" aria-hidden="false">
-    <section class="grid kpi-grid">
-
-      <article class="card">
-        <div class="kpi-title">Total Orders</div>
-        <div class="kpi-value">3,075</div>
-      </article>
-
-      <article class="card">
-        <div class="kpi-title">Total Units</div>
-        <div class="kpi-value">3,856</div>
-      </article>
-
-      <article class="card">
-        <div class="kpi-title">Total Revenue</div>
-        <div class="kpi-value">$294,677.05</div>
-      </article>
-
-      <article class="card">
-        <div class="kpi-title">Gross Proceed</div>
-        <div class="kpi-value">$170,933.70</div>
-      </article>
-
-      <article class="card">
-        <div class="kpi-title">Final Net</div>
-        <div class="kpi-value">$76,271.43</div>
-      </article>
-
-      <article class="card">
-        <div class="kpi-title">Ad Spend</div>
-        <div class="kpi-value">$17,680.62</div>
-      </article>
-
-      <article class="card">
-        <div class="kpi-title">Average Order Value</div>
-        <div class="kpi-value">$95.83</div>
-      </article>
-
-      <article class="card">
-        <div class="kpi-title">Net Margin</div>
-        <div class="kpi-value">25.9%</div>
-      </article>
-
-    </section>
-    <section class="grid analysis-grid">
-      <div class="card analysis-card analysis-card--wide">
-        <div class="card-header">
-          <h2 class="card-title">Revenue &amp; Profit Trend</h2>
+  <div class="tab-panel active" id="tab-lo" data-tab="lo" role="tabpanel" aria-labelledby="tab-lo-button" aria-hidden="false">
+    <section class="grid lo-grid">
+      <article class="card lo-card">
+        <header class="lo-card__header">
+          <h2 class="lo-card__title">Listing Owner performance</h2>
+          <p class="lo-card__subtitle">Daily breakdown of sales and ad spend by listing owner.</p>
+        </header>
+        <nav class="sub-tab-nav" aria-label="Listing owner metrics">
+          <button class="sub-tab-button active" id="lo-sales-button" type="button" data-subtab="sales" aria-controls="lo-sales-panel" aria-selected="true">Sales</button>
+          <button class="sub-tab-button" id="lo-spend-button" type="button" data-subtab="spend" aria-controls="lo-spend-panel" aria-selected="false">Spend</button>
+        </nav>
+        <div class="sub-tab-panel active" id="lo-sales-panel" data-subtab="sales" role="region" aria-labelledby="lo-sales-button">
+          <div class="table-container lo-table-container">
+            <table id="lo-sales-table" class="lo-table"></table>
+          </div>
         </div>
-        <div class="card-body">
-          <canvas id="daily-chart" class="analysis-chart" height="320"></canvas>
+        <div class="sub-tab-panel" id="lo-spend-panel" data-subtab="spend" role="region" aria-labelledby="lo-spend-button" aria-hidden="true">
+          <div class="table-container lo-table-container">
+            <table id="lo-spend-table" class="lo-table"></table>
+          </div>
         </div>
-      </div>
-      <div class="card analysis-card analysis-card--narrow">
-        <div class="card-header">
-          <h2 class="card-title">Top Categories by Final Net</h2>
-        </div>
-        <div class="card-body">
-          <canvas id="category-chart" class="analysis-chart" height="320"></canvas>
-        </div>
-      </div>
-      <div class="card analysis-card analysis-card--half">
-        <div class="card-header">
-          <h2 class="card-title">Store Mix</h2>
-        </div>
-        <div class="card-body">
-          <table class="analysis-table">
-            <caption>Store mix contribution to revenue and final net</caption>
-            <thead>
-              <tr><th scope="col">Store</th><th scope="col">Revenue</th><th scope="col">Final Net</th></tr>
-            </thead>
-            <tbody>
-              <tr><td>AMZ REG</td><td class="cell-numeric">$124,372.92</td><td class="cell-numeric">$33,852.24</td></tr><tr><td>AMZ FBA</td><td class="cell-numeric">$102,750.93</td><td class="cell-numeric">$25,503.26</td></tr><tr><td>Ebay/Walmart/Website</td><td class="cell-numeric">$45,620.58</td><td class="cell-numeric">$11,884.15</td></tr><tr><td>AMZ FBA CAN</td><td class="cell-numeric">$21,932.62</td><td class="cell-numeric">$5,031.77</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <div class="card analysis-card analysis-card--half">
-        <div class="card-header">
-          <h2 class="card-title">Top SKUs by Final Net</h2>
-        </div>
-        <div class="card-body">
-          <table class="analysis-table">
-            <caption>Top SKUs ranked by final net contribution</caption>
-            <thead>
-              <tr><th scope="col">Sku</th><th scope="col">Units</th><th scope="col">Final Net</th></tr>
-            </thead>
-            <tbody>
-              <tr><td>B5</td><td class="cell-numeric">92.0</td><td class="cell-numeric">$4,375.72</td></tr><tr><td>FAB-554</td><td class="cell-numeric">29.0</td><td class="cell-numeric">$3,459.89</td></tr><tr><td>V4-1824</td><td class="cell-numeric">82.0</td><td class="cell-numeric">$1,743.15</td></tr><tr><td>JMT-59</td><td class="cell-numeric">53.0</td><td class="cell-numeric">$1,740.86</td></tr><tr><td>V2</td><td class="cell-numeric">57.0</td><td class="cell-numeric">$1,713.33</td></tr><tr><td>V4F</td><td class="cell-numeric">34.0</td><td class="cell-numeric">$1,652.76</td></tr><tr><td>V2-1824</td><td class="cell-numeric">76.0</td><td class="cell-numeric">$1,572.41</td></tr><tr><td>V6</td><td class="cell-numeric">28.0</td><td class="cell-numeric">$1,538.79</td></tr><tr><td>B12</td><td class="cell-numeric">19.0</td><td class="cell-numeric">$1,352.49</td></tr><tr><td>S9X</td><td class="cell-numeric">53.0</td><td class="cell-numeric">$1,339.43</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
+      </article>
     </section>
   </div>
   <div class="tab-panel" id="tab-regular" data-tab="regular" role="tabpanel" aria-labelledby="tab-regular-button" aria-hidden="true">
@@ -657,18 +580,22 @@
     </section>
   </div>
   <script>
-    const dailySeries = [{"date":"2025-09-01","revenue":3991.5693,"final_net":967.6681849284316},{"date":"2025-09-02","revenue":27004.3933,"final_net":5892.861777578192},{"date":"2025-09-03","revenue":14134.1591,"final_net":3848.7080137782214},{"date":"2025-09-04","revenue":13442.0764,"final_net":3359.390823024803},{"date":"2025-09-05","revenue":11971.5861,"final_net":3618.287882891206},{"date":"2025-09-06","revenue":9740.0052,"final_net":2007.2764533166428},{"date":"2025-09-07","revenue":5705.8661,"final_net":1391.3388444349875},{"date":"2025-09-08","revenue":19917.309,"final_net":5278.163294205369},{"date":"2025-09-09","revenue":16891.3098,"final_net":4104.160668313585},{"date":"2025-09-10","revenue":10983.5059,"final_net":2793.2267988994954},{"date":"2025-09-11","revenue":11534.2453,"final_net":2952.569931535068},{"date":"2025-09-12","revenue":10964.039,"final_net":2845.538930056686},{"date":"2025-09-13","revenue":9547.360700000001,"final_net":2428.2749996529537},{"date":"2025-09-14","revenue":4074.278,"final_net":1013.0330780450196},{"date":"2025-09-15","revenue":19505.498,"final_net":4923.892216865558},{"date":"2025-09-16","revenue":13897.8109,"final_net":3922.1459336448174},{"date":"2025-09-17","revenue":12579.9332,"final_net":3216.836002467571},{"date":"2025-09-18","revenue":14542.710700000001,"final_net":4423.308448747652},{"date":"2025-09-19","revenue":17487.1466,"final_net":5014.889137143346},{"date":"2025-09-20","revenue":8814.6478,"final_net":2244.4181519997564},{"date":"2025-09-21","revenue":4477.4615,"final_net":1095.3186860311882},{"date":"2025-09-22","revenue":17893.8122,"final_net":4893.260047382762},{"date":"2025-09-23","revenue":15576.3226,"final_net":4036.8586775935028}];
-    const categorySeries = [{"category":"VB","final_net":15140.908496576283},{"category":"FAB","final_net":14584.070977783102},{"category":"CFB","final_net":13558.146840077734},{"category":"RCB","final_net":4736.489908168083},{"category":"JMT","final_net":4668.912872766931},{"category":"PF","final_net":3486.1491063341005},{"category":"GEN","final_net":3349.6331984126987},{"category":"HS","final_net":3252.2734973267548},{"category":"HB","final_net":2622.9348881312512},{"category":"CP","final_net":2139.163595413091}];
-
-    const fmtCurrency = (value) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
-    const fmtPercent = (value) => `${(value * 100).toFixed(1)}%`;
-
     const tabButtons = document.querySelectorAll('.tab-button');
     const tabPanels = document.querySelectorAll('.tab-panel');
+    const subTabButtons = document.querySelectorAll('.sub-tab-button');
+    const subTabPanels = document.querySelectorAll('.sub-tab-panel');
+
     let regularTable;
     let regularTableInitialised = false;
+    let datasetCache = null;
+    let datasetPromise = null;
+    let loTablesInitialised = false;
+
     const NUMERIC_COLUMN_EXCLUSIONS = new Set(['ORDER NO', 'PLAIN ORDER NO', 'ORDER #', 'ORDER NO.', 'CHECKOUT']);
     const ZERO_DECIMAL_COLUMNS = new Set(['qty', 'order no', 'plain order no', 'order no.', 'order #']);
+    const numberFormatter = new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    const displayDateFormatter = new Intl.DateTimeFormat('en-US', { day: '2-digit', month: 'short', year: 'numeric' });
+
     let columnValueOptions = [];
     let columnFilters = {};
     let headerMenuElement;
@@ -681,6 +608,31 @@
     const MAX_VISIBLE_ROWS = 16;
     const TABLE_BOTTOM_MARGIN = 24;
     const REGULAR_TABLE_PAGE_LENGTH = 200;
+
+    function fetchDataset() {
+      if (datasetCache) {
+        return Promise.resolve(datasetCache);
+      }
+      if (datasetPromise) {
+        return datasetPromise;
+      }
+      datasetPromise = fetch('regular_sep25_data.json')
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Unable to load dataset');
+          }
+          return response.json();
+        })
+        .then((data) => {
+          datasetCache = data;
+          return data;
+        })
+        .catch((error) => {
+          datasetPromise = null;
+          throw error;
+        });
+      return datasetPromise;
+    }
 
     function getStickyOffsetValue() {
       const rawValue = getComputedStyle(document.documentElement).getPropertyValue('--sticky-header-offset');
@@ -819,12 +771,48 @@
         refreshRegularTableLayout();
       } else {
         closeHeaderMenu();
+        if (targetTab === 'lo') {
+          if (!loTablesInitialised) {
+            renderLoMessage('Loading data…');
+          }
+          fetchDataset()
+            .then((dataset) => {
+              initializeLoTables(dataset);
+            })
+            .catch((error) => {
+              renderLoMessage(error.message || 'Unable to load data');
+            });
+        }
       }
     }
 
     tabButtons.forEach((button) => {
       button.addEventListener('click', () => setActiveTab(button.dataset.tab));
     });
+
+    function setActiveSubTab(targetSubTab) {
+      if (!subTabButtons.length) {
+        return;
+      }
+      subTabButtons.forEach((button) => {
+        const isActive = button.dataset.subtab === targetSubTab;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-selected', String(isActive));
+      });
+      subTabPanels.forEach((panel) => {
+        const isActive = panel.dataset.subtab === targetSubTab;
+        panel.classList.toggle('active', isActive);
+        panel.setAttribute('aria-hidden', String(!isActive));
+      });
+    }
+
+    subTabButtons.forEach((button) => {
+      button.addEventListener('click', () => setActiveSubTab(button.dataset.subtab));
+    });
+
+    if (subTabButtons.length > 0) {
+      setActiveSubTab('sales');
+    }
 
     function updateStickyOffset() {
       const headerEl = document.querySelector('header');
@@ -835,7 +823,7 @@
       document.documentElement.style.setProperty('--sticky-header-offset', `${offset}px`);
     }
 
-    setActiveTab('analysis');
+    setActiveTab('lo');
     updateStickyOffset();
     window.addEventListener('resize', () => {
       updateStickyOffset();
@@ -1103,7 +1091,7 @@
       return null;
     }
 
-    function formatExcelSerialDate(value) {
+    function parseExcelSerialToDate(value) {
       const numeric = parseNumericValue(value);
       if (numeric === null) {
         return null;
@@ -1118,7 +1106,12 @@
       const dayMilliseconds = 24 * 60 * 60 * 1000;
       const timestamp = excelEpoch + adjustedSerial * dayMilliseconds + Math.round(fractional * dayMilliseconds);
       const date = new Date(timestamp);
-      if (Number.isNaN(date.getTime())) {
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    function formatExcelSerialDate(value) {
+      const date = parseExcelSerialToDate(value);
+      if (!date) {
         return null;
       }
       const day = String(date.getUTCDate()).padStart(2, '0');
@@ -1172,17 +1165,132 @@
       return typeof value === 'string' ? value : String(value ?? '');
     }
 
+    function findColumnIndex(dataset, targetName) {
+      if (!dataset || !Array.isArray(dataset.columns)) {
+        return -1;
+      }
+      const normalizedTarget = targetName ? targetName.trim().toLowerCase() : '';
+      return dataset.columns.findIndex((column) => (column || '').trim().toLowerCase() === normalizedTarget);
+    }
+
+    function formatTwoDecimal(value) {
+      const numeric = Number.isFinite(value) ? value : 0;
+      return numberFormatter.format(numeric);
+    }
+
+    function buildLoPivot(dataset, targetColumnName) {
+      const checkoutIndex = findColumnIndex(dataset, 'checkout');
+      const ownerIndex = findColumnIndex(dataset, 'listing owner');
+      const valueIndex = findColumnIndex(dataset, targetColumnName);
+      if (checkoutIndex < 0 || ownerIndex < 0 || valueIndex < 0) {
+        return { loList: [], rows: [] };
+      }
+
+      const listingOwners = new Set();
+      const dateMap = new Map();
+
+      dataset.rows.forEach((row) => {
+        const date = parseExcelSerialToDate(row[checkoutIndex]);
+        if (!date) {
+          return;
+        }
+        const isoKey = date.toISOString().slice(0, 10);
+        const ownerRaw = row[ownerIndex];
+        let owner = '';
+        if (typeof ownerRaw === 'string') {
+          owner = ownerRaw.trim();
+        } else if (ownerRaw === null || ownerRaw === undefined) {
+          owner = '';
+        } else {
+          owner = String(ownerRaw).trim();
+        }
+        const ownerName = owner || 'Unassigned';
+
+        const rawValue = row[valueIndex];
+        const numericValue = parseNumericValue(rawValue);
+        const value = numericValue === null ? 0 : numericValue;
+
+        listingOwners.add(ownerName);
+        if (!dateMap.has(isoKey)) {
+          dateMap.set(isoKey, { date, values: new Map() });
+        }
+        const entry = dateMap.get(isoKey);
+        entry.values.set(ownerName, (entry.values.get(ownerName) ?? 0) + value);
+      });
+
+      const loList = Array.from(listingOwners).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+      const rows = Array.from(dateMap.values())
+        .sort((a, b) => a.date - b.date)
+        .map(({ date, values }) => {
+          const displayDate = displayDateFormatter.format(date);
+          const formattedValues = loList.map((owner) => formatTwoDecimal(values.get(owner) ?? 0));
+          return { displayDate, formattedValues };
+        });
+
+      return { loList, rows };
+    }
+
+    function renderLoTable(tableElement, pivotData) {
+      if (!tableElement) {
+        return;
+      }
+      const { loList, rows } = pivotData;
+      if (!loList.length || !rows.length) {
+        const columnCount = Math.max(1, loList.length + 1);
+        tableElement.innerHTML = `<tbody><tr><td class="cell-date" colspan="${columnCount}">No data available</td></tr></tbody>`;
+        return;
+      }
+
+      let headerHtml = '<thead><tr><th scope="col">Date</th>';
+      loList.forEach((owner) => {
+        headerHtml += `<th scope="col">${escapeHtml(owner)}</th>`;
+      });
+      headerHtml += '</tr></thead>';
+
+      let bodyHtml = '<tbody>';
+      rows.forEach(({ displayDate, formattedValues }) => {
+        bodyHtml += `<tr><td class="cell-date">${escapeHtml(displayDate)}</td>`;
+        formattedValues.forEach((value) => {
+          bodyHtml += `<td>${value}</td>`;
+        });
+        bodyHtml += '</tr>';
+      });
+      bodyHtml += '</tbody>';
+
+      tableElement.innerHTML = `${headerHtml}${bodyHtml}`;
+    }
+
+    function renderLoMessage(message) {
+      const escaped = escapeHtml(message);
+      const markup = `<tbody><tr><td class="cell-date" colspan="1">${escaped}</td></tr></tbody>`;
+      const salesTable = document.getElementById('lo-sales-table');
+      const spendTable = document.getElementById('lo-spend-table');
+      if (salesTable) {
+        salesTable.innerHTML = markup;
+      }
+      if (spendTable) {
+        spendTable.innerHTML = markup;
+      }
+    }
+
+    function initializeLoTables(dataset) {
+      if (loTablesInitialised) {
+        return;
+      }
+      const salesTable = document.getElementById('lo-sales-table');
+      const spendTable = document.getElementById('lo-spend-table');
+      const salesPivot = buildLoPivot(dataset, 'total revenue');
+      const spendPivot = buildLoPivot(dataset, 'ad spend');
+      renderLoTable(salesTable, salesPivot);
+      renderLoTable(spendTable, spendPivot);
+      loTablesInitialised = true;
+    }
+
     function loadRegularTable() {
       if (regularTableInitialised) {
         return;
       }
-      fetch('regular_sep25_data.json')
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error('Failed to load dataset');
-          }
-          return response.json();
-        })
+      fetchDataset()
         .then((dataset) => {
           updateStickyOffset();
 
@@ -1250,119 +1358,6 @@
         });
     }
 
-    const dailyCtx = document.getElementById('daily-chart');
-    if (dailySeries.length > 0) {
-      new Chart(dailyCtx, {
-        type: 'line',
-        data: {
-          labels: dailySeries.map(item => item.date),
-          datasets: [
-            {
-              label: 'Revenue',
-              data: dailySeries.map(item => item.revenue),
-              borderColor: '#145afc',
-              backgroundColor: 'rgba(20, 90, 252, 0.15)',
-              tension: 0.25,
-              fill: true,
-            },
-            {
-              label: 'Final Net',
-              data: dailySeries.map(item => item.final_net),
-              borderColor: '#ff7d4f',
-              backgroundColor: 'rgba(255, 125, 79, 0.15)',
-              tension: 0.25,
-              fill: true,
-            }
-          ]
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          layout: {
-            padding: { left: 12, right: 20, top: 8, bottom: 16 }
-          },
-          interaction: { mode: 'index', intersect: false },
-          stacked: false,
-          plugins: {
-            legend: {
-              position: 'top',
-              align: 'start',
-              labels: {
-                usePointStyle: true,
-                boxWidth: 10,
-                color: '#4a5168'
-              }
-            },
-            tooltip: {
-              callbacks: {
-                label: (ctx) => `${ctx.dataset.label}: ${fmtCurrency(ctx.parsed.y)}`
-              }
-            }
-          },
-          scales: {
-            x: {
-              grid: { display: false },
-              ticks: {
-                maxRotation: 0,
-                color: '#4a5168'
-              }
-            },
-            y: {
-              grid: { color: 'rgba(20, 90, 252, 0.08)' },
-              ticks: {
-                callback: (value) => fmtCurrency(value),
-                color: '#4a5168'
-              }
-            }
-          }
-        }
-      });
-    }
-
-    const categoryCtx = document.getElementById('category-chart');
-    if (categorySeries.length > 0) {
-      new Chart(categoryCtx, {
-        type: 'bar',
-        data: {
-          labels: categorySeries.map(item => item.category),
-          datasets: [{
-            label: 'Final Net',
-            data: categorySeries.map(item => item.final_net),
-            backgroundColor: '#145afc'
-          }]
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          layout: {
-            padding: { left: 12, right: 20, top: 12, bottom: 16 }
-          },
-          plugins: {
-            legend: { display: false },
-            tooltip: {
-              callbacks: {
-                label: (ctx) => fmtCurrency(ctx.parsed.y)
-              }
-            }
-          },
-          scales: {
-            x: {
-              grid: { display: false },
-              ticks: {
-                color: '#4a5168'
-              }
-            },
-            y: {
-              grid: { color: 'rgba(20, 90, 252, 0.08)' },
-              ticks: {
-                callback: (value) => fmtCurrency(value),
-                color: '#4a5168'
-              }
-            }
-          }
-        }
-      });
-    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the Analysis tab with an "LO - Sales & Spend" view containing nested Sales and Spend tables
- aggregate day-wise totals by listing owner from the regular dataset and render values with two-decimal formatting
- remove the unused analysis charts and reuse the dataset fetch logic across both dashboard tabs

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d769bd117c832993478ee19b95a6ef