### PR TITLE
Ensure total column index is tracked for Regular tab

### DIFF
--- a/analysis/index.html
+++ b/analysis/index.html
@@ -736,6 +736,7 @@
 
     let columnValueOptions = [];
     let columnFilters = {};
+    let totalColumnIndex = -1;
     let headerMenuElement;
     let activeHeaderCell = null;
     let activeColumnIndex = null;
@@ -1796,6 +1797,7 @@
           updateStickyOffset();
 
           const augmentedDataset = augmentDatasetWithTotals(dataset);
+          totalColumnIndex = augmentedDataset.totalColumnIndex;
           const columns = augmentedDataset.columns.map((title) => ({ title }));
           const formattedRows = augmentedDataset.rows.map((row) => row.map((value, index) => formatCellValue(value, augmentedDataset.columns[index])));
           const productColumnIndex = augmentedDataset.columns.indexOf('Product');


### PR DESCRIPTION
## Summary
- add a totalColumnIndex global for the Regular tab script
- capture the total column index when augmenting the dataset so downstream helpers use the proper value

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d7852d998c8329998160acf487007c