### PR TITLE
Improve dashboard scroll behaviour and footer spacing

### DIFF
--- a/analysis/index.html
+++ b/analysis/index.html
@@ -28,7 +28,8 @@
       min-height: 100vh;
       display: flex;
       flex-direction: column;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
     .tab-nav {
       display: flex;
@@ -161,6 +162,8 @@
       padding-bottom: 0;
       scroll-padding-bottom: 96px;
       display: block;
+      -webkit-overflow-scrolling: touch;
+      overscroll-behavior: contain;
     }
     .lo-table {
       width: 100%;
@@ -308,6 +311,7 @@
       overflow: visible;
       display: flex;
       flex-direction: column;
+      padding-bottom: 1rem;
     }
     .regular-table-container .dataTables_wrapper {
       flex: 1 1 auto;
@@ -1079,7 +1083,9 @@
           paddingBottom = Math.max(0, Math.ceil(footRect.height) - 6);
         }
       }
-      scrollBody.style.paddingBottom = paddingBottom > 0 ? `${paddingBottom}px` : '0px';
+      const MINIMUM_PADDING = 16;
+      const appliedPadding = Math.max(paddingBottom, MINIMUM_PADDING);
+      scrollBody.style.paddingBottom = `${appliedPadding}px`;
     }
 
     function applyTableHeight(table) {


### PR DESCRIPTION
## Summary
- allow the dashboard page to scroll vertically while keeping horizontal overflow hidden
- improve the listing owner tables with mobile-friendly scrolling behaviour
- add breathing room around the regular performance table and ensure its scroll body keeps space for the totals row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a059825483299a93813fe455812b