### PR TITLE
Move regular table pagination into header

### DIFF
--- a/analysis/index.html
+++ b/analysis/index.html
@@ -651,8 +651,8 @@
       font-size: 0.85rem;
       flex-wrap: wrap;
     }
-    .regular-table__footer .dataTables_info {
-      padding-top: 0 !important;
+    .regular-table__footer:empty {
+      display: none;
     }
     .regular-table__footer .dataTables_paginate {
       margin: 0 !important;
@@ -2175,8 +2175,8 @@
             paging: true,
             pageLength: REGULAR_TABLE_PAGE_LENGTH,
             lengthChange: false,
-            info: true,
-            dom: 't<"regular-table__footer"ip>'
+            info: false,
+            dom: 't<"regular-table__footer"p>'
           });
 
           moveRegularTablePagination();

--- a/analysis/index.html
+++ b/analysis/index.html
@@ -295,9 +295,17 @@
     }
     .regular-card__header {
       display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 1rem;
+      padding: 0;
+      flex-wrap: wrap;
+    }
+    .regular-card__heading {
+      display: flex;
       flex-direction: column;
       gap: 0.35rem;
-      padding: 0;
+      min-width: 0;
     }
     .regular-card__title {
       margin: 0;
@@ -309,6 +317,49 @@
       margin: 0;
       color: var(--muted);
       font-size: 0.95rem;
+    }
+    .regular-card__pagination {
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      min-height: 2.5rem;
+    }
+    .regular-card__pagination:empty {
+      display: none;
+    }
+    .regular-card__pagination .dataTables_paginate {
+      float: none;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+    .regular-card__pagination .paginate_button {
+      border-radius: 999px !important;
+      padding: 0.35rem 0.85rem;
+      border: 1px solid rgba(20, 90, 252, 0.25) !important;
+      color: var(--accent) !important;
+      background: #fff !important;
+      font-weight: 600;
+      transition: background 0.2s ease, border-color 0.2s ease;
+    }
+    .regular-card__pagination .paginate_button.current,
+    .regular-card__pagination .paginate_button:hover,
+    .regular-card__pagination .paginate_button:focus {
+      background: rgba(20, 90, 252, 0.12) !important;
+      border-color: rgba(20, 90, 252, 0.45) !important;
+      outline: none;
+    }
+    .regular-card__pagination .paginate_button:focus-visible {
+      box-shadow: 0 0 0 2px rgba(20, 90, 252, 0.35);
+    }
+    .regular-card__pagination .paginate_button.disabled,
+    .regular-card__pagination .paginate_button.disabled:hover {
+      opacity: 0.5;
+      cursor: not-allowed;
     }
     .regular-table-container {
       border-radius: 0.85rem;
@@ -772,6 +823,18 @@
       white-space: nowrap;
       border: 0;
     }
+    @media (max-width: 768px) {
+      .regular-card__header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.75rem;
+      }
+      .regular-card__pagination {
+        width: 100%;
+        justify-content: flex-start;
+        margin-left: 0;
+      }
+    }
     @media (max-width: 1280px) {
       .lo-grid {
         grid-template-columns: 1fr;
@@ -823,8 +886,11 @@
     <section class="grid">
       <article class="card regular-card">
         <header class="regular-card__header">
-          <h2 class="regular-card__title">Regular Performance</h2>
-          <p class="regular-card__subtitle">Detailed order and spend metrics across all listings</p>
+          <div class="regular-card__heading">
+            <h2 class="regular-card__title">Regular Performance</h2>
+            <p class="regular-card__subtitle">Detailed order and spend metrics across all listings</p>
+          </div>
+          <div class="regular-card__pagination" id="regular-table-pagination" aria-label="Regular table pagination"></div>
         </header>
         <div class="table-container regular-table-container">
           <table id="regular-table" class="display" style="width:100%"></table>
@@ -1228,6 +1294,27 @@
       applyTableHeight(regularTable);
       if (regularTableFooterValues.length) {
         renderFooterRow(regularTable);
+      }
+      moveRegularTablePagination();
+    }
+
+    function moveRegularTablePagination() {
+      const paginationHost = document.getElementById('regular-table-pagination');
+      const tableWrapper = document.getElementById('regular-table_wrapper');
+      if (!paginationHost || !tableWrapper) {
+        return;
+      }
+      let paginate = tableWrapper.querySelector('.dataTables_paginate');
+      if (!paginate) {
+        paginate = paginationHost.querySelector('.dataTables_paginate');
+      }
+      if (!paginate) {
+        paginationHost.textContent = '';
+        return;
+      }
+      if (paginate.parentElement !== paginationHost) {
+        paginationHost.textContent = '';
+        paginationHost.appendChild(paginate);
       }
     }
 
@@ -2092,6 +2179,7 @@
             dom: 't<"regular-table__footer"ip>'
           });
 
+          moveRegularTablePagination();
           buildColumnOptions(augmentedDataset);
           wireHeaderEvents(regularTable);
           applyTableHeight(regularTable);
@@ -2104,6 +2192,7 @@
             if (SHOW_REGULAR_TOTAL_ROW) {
               renderFooterRow(regularTable);
             }
+            moveRegularTablePagination();
           });
 
           regularTableInitialised = true;


### PR DESCRIPTION
## Summary
- move the regular table pagination controls into the card header and add styling for the new placement
- update the regular tab header layout to accommodate the pagination block while keeping the heading copy grouped together
- relocate the DataTables pagination element via script on initialisation and redraw so it stays inside the new header container

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7a97fabf0832982595921e753cbc8