### PR TITLE
Adjust SKU summary layout for better table visibility

### DIFF
--- a/analysis/index.html
+++ b/analysis/index.html
@@ -397,17 +397,23 @@
     .regular-table-container table {
       margin-top: 0;
     }
+    #tab-sku-summary .grid {
+      grid-auto-rows: auto;
+      align-content: flex-start;
+    }
     .sku-card {
       display: flex;
       flex-direction: column;
-      gap: 1rem;
+      gap: 0.75rem;
       flex: 1 1 auto;
-      min-height: calc(100vh - var(--sticky-header-offset) - 2.75rem);
+      min-height: 0;
+      max-height: clamp(24rem, calc(100vh - var(--sticky-header-offset) - 3.25rem), 60rem);
     }
     .sku-card__header {
       display: flex;
       flex-direction: column;
       gap: 0.35rem;
+      flex: 0 0 auto;
     }
     .sku-card__title {
       margin: 0;
@@ -426,7 +432,7 @@
       justify-content: flex-end;
       gap: 1rem;
       flex-wrap: wrap;
-      margin-top: 0.25rem;
+      margin-top: 0.1rem;
     }
     .sku-card__toolbar[data-active='false'] {
       display: none;
@@ -496,9 +502,15 @@
     }
     .sku-table-scroll {
       flex: 1 1 auto;
+      min-height: 0;
       overflow-x: auto;
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
+    }
+    @media (max-width: 768px) {
+      .sku-card {
+        max-height: none;
+      }
     }
     .sku-table {
       width: 100%;


### PR DESCRIPTION
## Summary
- reduce SKU summary card gap and remove forced full-height sizing so the panel can shrink with its contents
- cap the card height relative to the viewport and ensure the table scroll area respects the new layout
- tweak toolbar spacing and mobile behaviour so header, body, and totals remain visible together

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7bed76b58832995351aa2e8e486cd