### PR TITLE
Simplify tab appearance

### DIFF
--- a/analysis/index.html
+++ b/analysis/index.html
@@ -27,11 +27,11 @@
       --transition-snappy: 260ms;
       --transition-gentle: 340ms;
       --sticky-header-offset: 72px;
-      --tab-bar-bg: #dadce0;
-      --tab-border: #bdc1c6;
+      --tab-bar-bg: #ffffff;
+      --tab-border: #dfe1e5;
       --tab-active-bg: #ffffff;
-      --tab-inactive-bg: #dadce0;
-      --tab-inactive-hover-bg: #e3e6eb;
+      --tab-inactive-bg: rgba(95, 99, 104, 0.08);
+      --tab-inactive-hover-bg: rgba(95, 99, 104, 0.14);
       --tab-text: #202124;
       --tab-text-muted: #5f6368;
       font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -72,59 +72,35 @@
       justify-content: center;
       min-height: 2.75rem;
       padding: 0.45rem 1.6rem;
-      border: none;
+      border: 1px solid transparent;
       background: var(--tab-inactive-bg);
       font: inherit;
       color: var(--tab-text-muted);
       font-weight: 600;
       letter-spacing: 0.01em;
       cursor: pointer;
-      border-radius: 14px 14px 12px 12px;
+      border-radius: 999px;
       z-index: 1;
       transition:
         color var(--transition-snappy) ease,
         background var(--transition-snappy) ease,
         box-shadow var(--transition-snappy) ease,
+        border-color var(--transition-snappy) ease,
         letter-spacing var(--transition-snappy) ease;
-    }
-    .tab-button::before,
-    .tab-button::after {
-      content: "";
-      position: absolute;
-      top: 0;
-      width: 14px;
-      height: 100%;
-      background: inherit;
-      z-index: -1;
-      border-radius: 14px 14px 12px 12px;
-    }
-    .tab-button::before {
-      left: -14px;
-      border-radius: 14px 0 0 12px;
-    }
-    .tab-button::after {
-      right: -14px;
-      border-radius: 0 14px 12px 0;
-    }
-    .tab-button:first-child::before,
-    .tab-button:last-child::after {
-      display: none;
     }
     .tab-button:hover,
     .tab-button:focus-visible {
       color: var(--tab-text);
       background: var(--tab-inactive-hover-bg);
+      border-color: rgba(95, 99, 104, 0.18);
       outline: none;
     }
     .tab-button.active {
       color: var(--tab-text);
       background: var(--tab-active-bg);
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+      border-color: var(--tab-border);
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
       z-index: 2;
-    }
-    .tab-button.active::before,
-    .tab-button.active::after {
-      background: var(--tab-active-bg);
     }
     .tab-nav__indicator {
       display: none;


### PR DESCRIPTION
## Summary
- remove overlapping pseudo-elements from the dashboard tabs
- restyle the tabs with a white background and softer borders for a cleaner look

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de672ca7bc8329836fc24a960c5828